### PR TITLE
feat/py312-compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13-dev"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - master
     paths:
-      - ".github/workflows/test.yml"
+      - ".github/workflows/tests.yml"
       - "**.py"
   pull_request:
     branches:
       - master
     paths:
-      - ".github/workflows/test.yml"
+      - ".github/workflows/tests.yml"
       - "**.py"
 
 jobs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -535,4 +535,4 @@ testing = ["func-timeout", "jaraco.itertools"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "eab830dc3befbc19bb7c149e48641763ce360963d948395e4e3083143e4e71a8"
+content-hash = "a3c44312919a60caacafdd735ebcf331e311f80538353f8733a5e66ba30bcca1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ include = ["resources/**/*"]
 python = "^3.7"
 graphviz = ">=0.13.2,<0.21.0"
 jinja2 = ">=2.10,<4.0"
-typed-ast = "^1.5.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.3"


### PR DESCRIPTION
As discussed in multiple issues, but notably https://github.com/mingrammer/diagrams/issues/832#issuecomment-2329529817, remove typed-ast for 3.12 compatibility